### PR TITLE
Add unlock global command for some spi flash in sfud, like sst26vf serials

### DIFF
--- a/components/drivers/spi/sfud/inc/sfud_def.h
+++ b/components/drivers/spi/sfud/inc/sfud_def.h
@@ -175,6 +175,10 @@ if (!(EXPR))                                                                   \
 #define SFUD_DUMMY_DATA                                0xFF
 #endif
 
+#ifndef SFUD_UNLOCK_GLOBAL
+#define SFUD_UNLOCK_GLOBAL                              0x98
+#endif
+
 /* maximum number of erase type support on JESD216 (V1.0) */
 #define SFUD_SFDP_ERASE_TYPE_MAX_NUM                      4
 

--- a/components/drivers/spi/sfud/inc/sfud_flash_def.h
+++ b/components/drivers/spi/sfud/inc/sfud_flash_def.h
@@ -44,6 +44,7 @@ enum sfud_write_mode {
     SFUD_WM_BYTE = 1 << 1,                                 /**< byte write */
     SFUD_WM_AAI = 1 << 2,                                  /**< auto address increment */
     SFUD_WM_DUAL_BUFFER = 1 << 3,                          /**< dual-buffer write, like AT45DB series */
+    SFUD_WM_PROTECT = 1 << 4,                              /**< use protect feature, like SST26VF016B */
 };
 
 /* manufacturer information */
@@ -129,6 +130,7 @@ typedef struct {
     {"W25Q128BV", SFUD_MF_ID_WINBOND, 0x40, 0x18, 16L*1024L*1024L, SFUD_WM_PAGE_256B, 4096, 0x20},                  \
     {"W25Q256FV", SFUD_MF_ID_WINBOND, 0x40, 0x19, 32L*1024L*1024L, SFUD_WM_PAGE_256B, 4096, 0x20},                  \
     {"SST25VF016B", SFUD_MF_ID_SST, 0x25, 0x41, 2L*1024L*1024L, SFUD_WM_BYTE|SFUD_WM_AAI, 4096, 0x20},              \
+    {"SST26VF016B", SFUD_MF_ID_SST, 0x26, 0x41, 2L*1024L*1024L, SFUD_WM_PAGE_256B|SFUD_WM_PROTECT, 4096, 0x20},     \
     {"M25P32", SFUD_MF_ID_MICRON, 0x20, 0x16, 4L*1024L*1024L, SFUD_WM_PAGE_256B, 64L*1024L, 0xD8},                  \
     {"M25P80", SFUD_MF_ID_MICRON, 0x20, 0x14, 1L*1024L*1024L, SFUD_WM_PAGE_256B, 64L*1024L, 0xD8},                  \
     {"M25P40", SFUD_MF_ID_MICRON, 0x20, 0x13, 512L*1024L, SFUD_WM_PAGE_256B, 64L*1024L, 0xD8},                      \


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[ 
Add unlock global command for some spi flash in sfud, like sst26vf serials.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;
目前有部分SPI Flash上电后默认是锁住的，此时通过写允许指令是没有办法真正写入的，必须要发送Global Un-Lock指令才能写入。因此需要增加这个指令及相关的代码，在硬件复位时执行全局开锁。

已经在Microchip ATSAMD21 的demo板上测试通过，验证了SST26VF016B的SPI Flash.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
